### PR TITLE
feat: extended AddSoftware to hold the identifier

### DIFF
--- a/cdm-dcd-reference/reference/reference.go
+++ b/cdm-dcd-reference/reference/reference.go
@@ -70,7 +70,7 @@ func (m *ReferenceClassDriver) Start(jobId uint32, deviceChannel chan []*generat
 		"1.0.0",
 		serialNumber)
 
-	deviceInfo.AddSoftware("firmware", "1.2.5")
+	deviceInfo.AddSoftware("FirmwareVersion", "1.2.5", "IDTA 02006-2-0")
 	deviceInfo.AddCapabilities("firmware_update", false)
 
 	randomMacAddress := generateRandomMacAddress()

--- a/cookiecutter-project-template/{{ cookiecutter.al_id }}/handler/handler.go
+++ b/cookiecutter-project-template/{{ cookiecutter.al_id }}/handler/handler.go
@@ -69,6 +69,7 @@ func (m *AssetLinkImplementation) Start(jobId uint32, deviceChannel chan []*gene
 		productVersion,
 		serialNumber)
 
+	deviceInfo.AddSoftware("FirmwareVersion", "1.2.5", "IDTA 02006-2-0")
 	device.AddCapabilities("firmware_update", false)
 
 	randomMacAddress := generateRandomMacAddress()

--- a/model/nameplate.go
+++ b/model/nameplate.go
@@ -61,10 +61,11 @@ func (d *DeviceInfo) AddNameplate(manufacturerName string,
 }
 
 // AddSoftware Add software information to an asset
-func (d *DeviceInfo) AddSoftware(name string, version string) {
+func (d *DeviceInfo) AddSoftware(name string, version string, identifierType string) {
 	softwareIdentifier := SoftwareIdentifier{
-		Name:    &name,
-		Version: &version,
+		Name:           &name,
+		Version:        &version,
+		IdentifierType: &identifierType,
 	}
 
 	softwareArtifact := SoftwareArtifact{

--- a/model/nameplate_test.go
+++ b/model/nameplate_test.go
@@ -41,8 +41,8 @@ func TestSoftwareNameplate(t *testing.T) {
 	t.Run("AddFirmware", func(t *testing.T) {
 		m := NewDevice("", "")
 
-		m.AddSoftware("ArtifactName", "0.1.2")
-		m.AddSoftware("ArtifactName1", "2.1.3")
+		m.AddSoftware("ArtifactName", "0.1.2", "TypeDefinitionName")
+		m.AddSoftware("ArtifactName1", "2.1.3", "TypeDefinitionName_2")
 
 		firmware := m.getFirmware()
 		if len(firmware) != 2 {
@@ -55,6 +55,7 @@ func TestSoftwareNameplate(t *testing.T) {
 				found++
 				assert.Equal(t, "ArtifactName", *v.Artifact.SoftwareIdentifier.Name)
 				assert.Equal(t, "0.1.2", *v.Artifact.SoftwareIdentifier.Version)
+				assert.Equal(t, "TypeDefinitionName", *v.Artifact.SoftwareIdentifier.IdentifierType)
 				break
 			}
 		}


### PR DESCRIPTION
Extend the digital nameplate to hold the Software type identifier as well.
This can be used to agree on hooks / versions to show users when using a device management.
The reference implementation uses 'Firmware Version' as defined in [IDTA](https://industrialdigitaltwin.org/wp-content/uploads/2022/10/IDTA-02006-2-0_Submodel_Digital-Nameplate.pdf)


Signed-off-by Dominik Tacke <dominik.tacke@siemens.com>