### PR TITLE
Add container image creation to generated AL project

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -122,6 +122,13 @@ jobs:
         run: |
           cd $TEST_PROJECT/$TEST_PROJECT_NAME/
           go test -v ./...
+      - name: Test Goreleaser Config (dry-run)
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          workdir: ${{ env.TEST_PROJECT }}/${{ env.TEST_PROJECT_NAME }}/
+          args: release --clean --snapshot
 
   release-sdk:
     runs-on: ubuntu-latest

--- a/cookiecutter-project-template/{{ cookiecutter.al_project }}/.goreleaser.yaml
+++ b/cookiecutter-project-template/{{ cookiecutter.al_project }}/.goreleaser.yaml
@@ -87,6 +87,36 @@ snapshot:
   name_template: "{{ incpatch .Version }}-next"
   {% endraw %}
 
+dockers:
+  - id: {{ cookiecutter.al_project }}-linux-amd64
+    ids:
+      - {{ cookiecutter.al_project }}
+    image_templates:
+      - {{ cookiecutter.al_project }}{% raw %}:{{ .Tag }}-linux-amd64{% endraw %}
+    dockerfile: Dockerfile
+    use: buildx
+    goos: linux
+    goarch: amd64
+    build_flag_templates:
+      - "--platform=linux/amd64"
+  - id: {{ cookiecutter.al_project }}-arm64
+    ids:
+      - {{ cookiecutter.al_project }}
+    image_templates:
+      - {{ cookiecutter.al_project }}{% raw %}:{{ .Tag }}-linux-arm64{% endraw %}
+    dockerfile: Dockerfile
+    use: buildx
+    goos: linux
+    goarch: amd64
+    build_flag_templates:
+      - --platform=linux/arm64
+
+docker_manifests:
+  - name_template: "{{ cookiecutter.al_project }}{% raw %}:{{ .Tag }}"{% endraw %}
+    image_templates:
+      - "{{ cookiecutter.al_project }}{% raw %}:{{ .Tag }}-linux-amd64"{% endraw %}
+      - "{{ cookiecutter.al_project }}{% raw %}:{{ .Tag }}-linux-arm64"{% endraw %}
+
 changelog:
   sort: asc
   groups:

--- a/cookiecutter-project-template/{{ cookiecutter.al_project }}/.goreleaser.yaml
+++ b/cookiecutter-project-template/{{ cookiecutter.al_project }}/.goreleaser.yaml
@@ -4,6 +4,8 @@
 ---
 project_name: {{ cookiecutter.al_project }}
 
+version: 2
+
 before:
   hooks:
     - go generate ./...
@@ -92,7 +94,8 @@ dockers:
     ids:
       - {{ cookiecutter.al_project }}
     image_templates:
-      - {{ cookiecutter.al_project }}{% raw %}:{{ .Tag }}-linux-amd64{% endraw %}
+      - "{{ cookiecutter.al_project }}{% raw %}:{{ .Tag }}-linux-amd64{% endraw %}"
+      - "{{ cookiecutter.al_project }}:latest-linux-amd64"
     dockerfile: Dockerfile
     use: buildx
     goos: linux
@@ -103,7 +106,8 @@ dockers:
     ids:
       - {{ cookiecutter.al_project }}
     image_templates:
-      - {{ cookiecutter.al_project }}{% raw %}:{{ .Tag }}-linux-arm64{% endraw %}
+      - "{{ cookiecutter.al_project }}{% raw %}:{{ .Tag }}-linux-arm64{% endraw %}"
+      - "{{ cookiecutter.al_project }}:latest-linux-arm64"
     dockerfile: Dockerfile
     use: buildx
     goos: linux
@@ -112,10 +116,14 @@ dockers:
       - --platform=linux/arm64
 
 docker_manifests:
-  - name_template: "{{ cookiecutter.al_project }}{% raw %}:{{ .Tag }}"{% endraw %}
+  - name_template: "{{ cookiecutter.al_project }}{% raw %}:{{ .Tag }}{% endraw %}"
     image_templates:
-      - "{{ cookiecutter.al_project }}{% raw %}:{{ .Tag }}-linux-amd64"{% endraw %}
-      - "{{ cookiecutter.al_project }}{% raw %}:{{ .Tag }}-linux-arm64"{% endraw %}
+      - "{{ cookiecutter.al_project }}{% raw %}:{{ .Tag }}-linux-amd64{% endraw %}"
+      - "{{ cookiecutter.al_project }}{% raw %}:{{ .Tag }}-linux-arm64{% endraw %}"
+  - name_template: "{{ cookiecutter.al_project }}:latest"
+    image_templates:
+      - "{{ cookiecutter.al_project }}:latest-linux-amd64"
+      - "{{ cookiecutter.al_project }}:latest-linux-arm64"
 
 changelog:
   sort: asc

--- a/cookiecutter-project-template/{{ cookiecutter.al_project }}/Dockerfile
+++ b/cookiecutter-project-template/{{ cookiecutter.al_project }}/Dockerfile
@@ -1,12 +1,9 @@
 # SPDX-FileCopyrightText: {{cookiecutter.year}} {{cookiecutter.company}}
 #
 # SPDX-License-Identifier: MIT
-#
-# Author: {{cookiecutter.author_name}} <{{cookiecutter.author_email}}>
 
 FROM scratch
 
 COPY --chmod=0755 {{ cookiecutter.al_project }} /al
 
-# This servers assumes that it is reachable with the name of the Asset Link inside the container network.
-ENTRYPOINT ["/al", "-grpc-server-endpoint-address={{ cookiecutter.al_project }}", "-grpc-server-address=:8081","-grpc-registry-address=grpc-server-registry:50051"]
+ENTRYPOINT ["/al"]

--- a/cookiecutter-project-template/{{ cookiecutter.al_project }}/Dockerfile
+++ b/cookiecutter-project-template/{{ cookiecutter.al_project }}/Dockerfile
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: {{cookiecutter.year}} {{cookiecutter.company}}
+#
+# SPDX-License-Identifier: MIT
+#
+# Author: {{cookiecutter.author_name}} <{{cookiecutter.author_email}}>
+
+FROM scratch
+
+COPY --chmod=0755 {{ cookiecutter.al_project }} /al
+
+# This servers assumes that it is reachable with the name of the Asset Link inside the container network.
+ENTRYPOINT ["/al", "-grpc-server-endpoint-address={{ cookiecutter.al_project }}", "-grpc-server-address=:8081","-grpc-registry-address=grpc-server-registry:50051"]

--- a/cookiecutter-project-template/{{ cookiecutter.al_project }}/docker-compose.yml
+++ b/cookiecutter-project-template/{{ cookiecutter.al_project }}/docker-compose.yml
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: {{cookiecutter.year}} {{cookiecutter.company}}
+#
+# SPDX-License-Identifier: MIT
+#
+# Starts the {{ cookiecutter.al_project }} Asset Link for Industrial Asset Hub (IAH)
+# Depends on an IAH gateway
+
+services:
+  {{ cookiecutter.al_project }}:
+    restart: always
+    image: '{{ cookiecutter.al_project }}:latest-${AL_OS}-${AL_ARCH}'
+    networks:
+      - 01-cdm
+    command:
+      - '-grpc-server-endpoint-address={{ cookiecutter.al_project }}'
+      - '-grpc-server-address=:8081'
+      - '-grpc-registry-address=grpc-server-registry:50051'
+    ports:
+      - 8081:8081
+
+networks:
+  01-cdm:
+    name: cdm
+    external: true

--- a/cookiecutter-project-template/{{ cookiecutter.al_project }}/start-asset-link.sh
+++ b/cookiecutter-project-template/{{ cookiecutter.al_project }}/start-asset-link.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: {{cookiecutter.year}} {{cookiecutter.company}}
+#
+# SPDX-License-Identifier: MIT
+
+OS=linux
+ARCH=$(uname -m)
+
+if [[ "$ARCH" == "x86_64" ]]; then
+    ARCH=amd64
+fi
+
+AL_OS=$OS AL_ARCH=$ARCH docker-compose up


### PR DESCRIPTION
### Description

Al are mostly integrated inside Edge Platforms. Container engines like Docker are mostly used on such ecosystems, to execute application which are stored inside so called containers.

This PR enhances the Goreleaser pipeline, to automatically generate Docker container by-default.


#### Issues Addressed

List and link all the issues addressed by this PR.

#### Change Type

Please select the relevant options:

- [ ] Bug fix (non-breaking change that resolves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

#### Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document.
- [x] My changes adhere to the established code style, patterns, and best practices.
- [ ] I have added tests that demonstrate the effectiveness of my changes.
- [ ] I have updated the documentation accordingly (if applicable).
