### PR TITLE
fix: manufacturer product id should not be passed empty

### DIFF
--- a/cdm-al-reference/reference/reference.go
+++ b/cdm-al-reference/reference/reference.go
@@ -82,7 +82,11 @@ func (m *ReferenceClassDriver) Discover(discoveryConfig config.DiscoveryConfig, 
 			deviceInfo := model.NewDevice("EthernetDevice", name)
 
 			uriOfTheProduct := fmt.Sprintf("https://%s/%s-%s", strings.ReplaceAll(manufacturer, " ", "_"), strings.ReplaceAll(product, " ", "_"), serialNumber)
-			deviceInfo.AddNameplate(manufacturer, uriOfTheProduct, "MyOrderNumber", product, "1.0.0", serialNumber)
+			err := deviceInfo.AddNameplate(manufacturer, uriOfTheProduct, "MyOrderNumber", product, "1.0.0", serialNumber)
+			if err != nil {
+				log.Err(err).Msg("Error while adding nameplate")
+				return err
+			}
 
 			deviceInfo.AddSoftware("firmware", "1.2.5")
 			deviceInfo.AddCapabilities("firmware_update", false)
@@ -93,7 +97,7 @@ func (m *ReferenceClassDriver) Discover(discoveryConfig config.DiscoveryConfig, 
 			deviceInfo.AddIPv4(id, deviceIPs[1], "255.255.255.0", "")
 			discoveredDevice := deviceInfo.ConvertToDiscoveredDevice()
 
-			err := devicePublisher.PublishDevice(discoveredDevice)
+			err = devicePublisher.PublishDevice(discoveredDevice)
 			if err != nil {
 				// discovery request was likely cancelled -> terminate discovery and return error
 				log.Error().Msgf("Publishing Error: %v", err)

--- a/cookiecutter-project-template/{{ cookiecutter.al_project }}/handler/handler.go
+++ b/cookiecutter-project-template/{{ cookiecutter.al_project }}/handler/handler.go
@@ -74,13 +74,17 @@ func (m *AssetLinkImplementation) Discover(discoveryConfig config.DiscoveryConfi
 	lastSerialNumber.Add(1)
 	serialNumber := fmt.Sprint(lastSerialNumber.Load())
 	productUri := fmt.Sprintf("urn:%s/%s/%s", strings.ReplaceAll(vendorName, " ", "_"), strings.ReplaceAll(product, " ", "_"), serialNumber)
-	deviceInfo.AddNameplate(
+	err := deviceInfo.AddNameplate(
 		vendorName,
 		productUri,
 		orderNumber,
 		product,
 		productVersion,
 		serialNumber)
+	if err != nil {
+		log.Err(err).Msg("Error while adding nameplate")
+		return err
+	}
 
 	deviceInfo.AddCapabilities("firmware_update", false)
 

--- a/cookiecutter-project-template/{{ cookiecutter.al_project }}/handler/handler.go
+++ b/cookiecutter-project-template/{{ cookiecutter.al_project }}/handler/handler.go
@@ -74,7 +74,7 @@ func (m *AssetLinkImplementation) Discover(discoveryConfig config.DiscoveryConfi
 	lastSerialNumber.Add(1)
 	serialNumber := fmt.Sprint(lastSerialNumber.Load())
 	productUri := fmt.Sprintf("urn:%s/%s/%s", strings.ReplaceAll(vendorName, " ", "_"), strings.ReplaceAll(product, " ", "_"), serialNumber)
-	err = deviceInfo.AddNameplate(
+	err := deviceInfo.AddNameplate(
 		vendorName,
 		productUri,
 		orderNumber,
@@ -95,7 +95,7 @@ func (m *AssetLinkImplementation) Discover(discoveryConfig config.DiscoveryConfi
 	// Convert and publish device
 	discoveredDevice := deviceInfo.ConvertToDiscoveredDevice()
 
-	err := devicePublisher.PublishDevice(discoveredDevice)
+	err = devicePublisher.PublishDevice(discoveredDevice)
 	if err != nil {
 		// discovery request was likely cancelled -> terminate discovery and return error
 		log.Error().Msgf("Publishing Error: %v", err)

--- a/cookiecutter-project-template/{{ cookiecutter.al_project }}/handler/handler.go
+++ b/cookiecutter-project-template/{{ cookiecutter.al_project }}/handler/handler.go
@@ -74,7 +74,7 @@ func (m *AssetLinkImplementation) Discover(discoveryConfig config.DiscoveryConfi
 	lastSerialNumber.Add(1)
 	serialNumber := fmt.Sprint(lastSerialNumber.Load())
 	productUri := fmt.Sprintf("urn:%s/%s/%s", strings.ReplaceAll(vendorName, " ", "_"), strings.ReplaceAll(product, " ", "_"), serialNumber)
-	err := deviceInfo.AddNameplate(
+	err = deviceInfo.AddNameplate(
 		vendorName,
 		productUri,
 		orderNumber,

--- a/model/capabilities.go
+++ b/model/capabilities.go
@@ -13,7 +13,7 @@ package model
 func (d *DeviceInfo) AddCapabilities(name string, enabled bool) {
 	operation := AssetOperation{}
 
-	if isNonEmptyValues(name) {
+	if checkIfAnyValueIsNonEmpty(name) {
 		enabled = true
 		operation.OperationName = &name
 		operation.ActivationFlag = &enabled

--- a/model/convert-to-discovered-device.go
+++ b/model/convert-to-discovered-device.go
@@ -123,7 +123,7 @@ func convertToDeviceIdentifier(value interface{}, identifierUri string) *generat
 	}
 	switch v := value.(type) {
 	case string:
-		if isNonEmptyValues(value.(string)) {
+		if checkIfAnyValueIsNonEmpty(value.(string)) {
 			identifier.Value = &generated.DeviceIdentifier_Text{Text: v}
 		}
 	case *string:
@@ -210,7 +210,7 @@ func convertStructTypeToDeviceIdentifiers(valueStruct reflect.Value, prefixUri s
 	return structIdentifiers
 }
 
-func isNonEmptyValues(values ...string) bool {
+func checkIfAnyValueIsNonEmpty(values ...string) bool {
 	for _, value := range values {
 		if value != "" {
 			return true

--- a/model/convert_e2e_test.go
+++ b/model/convert_e2e_test.go
@@ -45,7 +45,10 @@ func getTestDevice() *DeviceInfo {
 	deviceInfo := NewDevice("Asset", "TestDevice")
 
 	uriOfTheProduct := fmt.Sprintf("https://%s/%s-%s", strings.ReplaceAll(manufacturer, " ", "_"), strings.ReplaceAll(product, " ", "_"), serialNumber)
-	deviceInfo.AddNameplate(manufacturer, uriOfTheProduct, "MyOrderNumber", product, "1.0.0", serialNumber)
+	err := deviceInfo.AddNameplate(manufacturer, uriOfTheProduct, "MyOrderNumber", product, "1.0.0", serialNumber)
+	if err != nil {
+		return nil
+	}
 	deviceInfo.AddSoftware("firmware", "1.2.5")
 	macAddress := "00:00:00:00:00:00"
 	deviceNIC := "enp0"

--- a/model/helper.go
+++ b/model/helper.go
@@ -9,7 +9,7 @@ package model
 
 func (d *DeviceInfo) addIdentifier(mac string) {
 
-	if isNonEmptyValues(mac) {
+	if checkIfAnyValueIsNonEmpty(mac) {
 		identifierUncertainty := 1
 		identifier := MacIdentifier{
 			IdentifierType:        nil,

--- a/model/model.go
+++ b/model/model.go
@@ -21,7 +21,7 @@ const (
 func NewDevice(typeOfAsset string, assetName string) *DeviceInfo {
 
 	d := DeviceInfo{}
-	if !isNonEmptyValues(typeOfAsset) {
+	if !checkIfAnyValueIsNonEmpty(typeOfAsset) {
 		log.Warn().Msg("Asset type is empty")
 		return &d
 	}

--- a/model/nameplate.go
+++ b/model/nameplate.go
@@ -27,7 +27,7 @@ func (d *DeviceInfo) AddNameplate(manufacturerName string, uriOfTheProduct strin
 	productArticleNumberOfManufacturer string, manufacturerProductDesignation string, hardwareVersion string, serialNumber string) error {
 
 	// URI of the product is a required property
-	if checkIfAnyValueIsNonEmpty(uriOfTheProduct) {
+	if !checkIfAnyValueIsNonEmpty(uriOfTheProduct) {
 		return errors.New("URI of the product should not be empty")
 	}
 

--- a/model/nameplate.go
+++ b/model/nameplate.go
@@ -27,11 +27,12 @@ func (d *DeviceInfo) AddNameplate(manufacturerName string, uriOfTheProduct strin
 	productArticleNumberOfManufacturer string, manufacturerProductDesignation string, hardwareVersion string, serialNumber string) (err error) {
 
 	// URI of the product is a required property
-	if uriOfTheProduct == "" {
+	if checkIfAnyValueIsNonEmpty(uriOfTheProduct) {
 		return errors.New("URI of the product should not be empty")
 	}
 
-	if isNonEmptyValues(manufacturerName, uriOfTheProduct, productArticleNumberOfManufacturer, manufacturerProductDesignation, hardwareVersion, serialNumber) {
+	// this check ensures if any field is non-empty then its value is set
+	if checkIfAnyValueIsNonEmpty(manufacturerName, productArticleNumberOfManufacturer, manufacturerProductDesignation, hardwareVersion, serialNumber) {
 
 		// We hash the manufacturer to get a unique identifier
 		h := sha1.New()
@@ -70,7 +71,7 @@ func (d *DeviceInfo) AddNameplate(manufacturerName string, uriOfTheProduct strin
 func (d *DeviceInfo) AddSoftware(name string, version string) {
 	softwareIdentifier := SoftwareIdentifier{}
 
-	if isNonEmptyValues(name, version) {
+	if checkIfAnyValueIsNonEmpty(name, version) {
 		softwareIdentifier.Name = &name
 		softwareIdentifier.Version = &version
 	}

--- a/model/nameplate.go
+++ b/model/nameplate.go
@@ -10,6 +10,7 @@ package model
 import (
 	"crypto/sha1"
 	"encoding/hex"
+	"errors"
 )
 
 // AddNameplate Add a digital nameplate to an asset.
@@ -22,13 +23,13 @@ import (
 // hardwareVersion: version of the hardware supplied with the device
 // serialNumber: unique combination of numbers and letters used to identify
 // the device once it has been manufactured
-func (d *DeviceInfo) AddNameplate(manufacturerName string,
-	uriOfTheProduct string,
-	productArticleNumberOfManufacturer string,
-	manufacturerProductDesignation string,
-	hardwareVersion string,
-	serialNumber string,
-) {
+func (d *DeviceInfo) AddNameplate(manufacturerName string, uriOfTheProduct string,
+	productArticleNumberOfManufacturer string, manufacturerProductDesignation string, hardwareVersion string, serialNumber string) (err error) {
+
+	// URI of the product is a required property
+	if uriOfTheProduct == "" {
+		return errors.New("URI of the product should not be empty")
+	}
 
 	if isNonEmptyValues(manufacturerName, uriOfTheProduct, productArticleNumberOfManufacturer, manufacturerProductDesignation, hardwareVersion, serialNumber) {
 
@@ -62,6 +63,7 @@ func (d *DeviceInfo) AddNameplate(manufacturerName string,
 
 		d.ProductInstanceIdentifier = &pi
 	}
+	return err
 }
 
 // AddSoftware Add software information to an asset

--- a/model/nameplate.go
+++ b/model/nameplate.go
@@ -24,7 +24,7 @@ import (
 // serialNumber: unique combination of numbers and letters used to identify
 // the device once it has been manufactured
 func (d *DeviceInfo) AddNameplate(manufacturerName string, uriOfTheProduct string,
-	productArticleNumberOfManufacturer string, manufacturerProductDesignation string, hardwareVersion string, serialNumber string) (err error) {
+	productArticleNumberOfManufacturer string, manufacturerProductDesignation string, hardwareVersion string, serialNumber string) error {
 
 	// URI of the product is a required property
 	if checkIfAnyValueIsNonEmpty(uriOfTheProduct) {
@@ -64,7 +64,7 @@ func (d *DeviceInfo) AddNameplate(manufacturerName string, uriOfTheProduct strin
 
 		d.ProductInstanceIdentifier = &pi
 	}
-	return err
+	return nil
 }
 
 // AddSoftware Add software information to an asset

--- a/model/nameplate_test.go
+++ b/model/nameplate_test.go
@@ -19,13 +19,14 @@ func TestNameplate(t *testing.T) {
 	t.Run("AddNameplate", func(t *testing.T) {
 		m := NewDevice("asset", "device")
 
-		m.AddNameplate(
+		err := m.AddNameplate(
 			"ManufacturerCompany",
 			"GuidOfTheProduct",
 			"MyOrderNumber",
 			"ProductFamily",
 			"0.1.2",
 			"s-n-1.2.3")
+		assert.Nil(t, err)
 
 		// ManufacturerProductDesignation
 		assert.Equal(t, "ManufacturerCompany", *m.ProductInstanceIdentifier.ManufacturerProduct.Manufacturer.Name)
@@ -34,6 +35,18 @@ func TestNameplate(t *testing.T) {
 		assert.Equal(t, "0.1.2", *m.ProductInstanceIdentifier.ManufacturerProduct.ProductVersion)
 		assert.Equal(t, "MyOrderNumber", *m.ProductInstanceIdentifier.ManufacturerProduct.ProductId)
 		assert.Equal(t, "s-n-1.2.3", *m.ProductInstanceIdentifier.SerialNumber)
+	})
+	t.Run("AddNameplate when uri of the product is not passed should fail", func(t *testing.T) {
+		m := NewDevice("asset", "device")
+
+		err := m.AddNameplate(
+			"ManufacturerCompany",
+			"",
+			"MyOrderNumber",
+			"ProductFamily",
+			"0.1.2",
+			"s-n-1.2.3")
+		assert.NotNil(t, err)
 	})
 }
 

--- a/model/network.go
+++ b/model/network.go
@@ -17,7 +17,7 @@ import (
 // No validation of is currently done
 func (d *DeviceInfo) AddNic(name string, macAddress string) (nicId string) {
 
-	if isNonEmptyValues(macAddress) {
+	if checkIfAnyValueIsNonEmpty(macAddress) {
 		nicId = uuid.New().String()
 
 		t := EthernetPortConnectionPointTypeEthernetPort
@@ -29,7 +29,7 @@ func (d *DeviceInfo) AddNic(name string, macAddress string) (nicId string) {
 		}
 
 		nameKey := "name"
-		if isNonEmptyValues(name) {
+		if checkIfAnyValueIsNonEmpty(name) {
 			nic.InstanceAnnotations = []InstanceAnnotation{{
 				Key:   &nameKey,
 				Value: &name,
@@ -52,7 +52,7 @@ func (d *DeviceInfo) AddNic(name string, macAddress string) (nicId string) {
 // No validation of is currently done
 func (d *DeviceInfo) AddIPv4(nicId string, address string, networkMask string, router string) (id string) {
 
-	if isNonEmptyValues(address) {
+	if checkIfAnyValueIsNonEmpty(address) {
 		id = uuid.New().String()
 
 		t := Ipv4ConnectivityConnectionPointTypeIpv4Connectivity
@@ -68,7 +68,7 @@ func (d *DeviceInfo) AddIPv4(nicId string, address string, networkMask string, r
 			Ipv4Address:             &address,
 			RelatedConnectionPoints: []RelatedConnectionPoint{relationship},
 		}
-		if isNonEmptyValues(networkMask, router) {
+		if checkIfAnyValueIsNonEmpty(networkMask, router) {
 			ipv4.NetworkMask = &networkMask
 			ipv4.RouterIpv4Address = &router
 		}
@@ -84,7 +84,7 @@ func (d *DeviceInfo) AddIPv4(nicId string, address string, networkMask string, r
 // No validation of is currently done
 func (d *DeviceInfo) AddIPv6(nicId string, address string, networkMask string, router string) (id string) {
 
-	if isNonEmptyValues(address) {
+	if checkIfAnyValueIsNonEmpty(address) {
 		id = uuid.New().String()
 
 		t := Ipv6ConnectivityConnectionPointTypeIpv6Connectivity
@@ -100,7 +100,7 @@ func (d *DeviceInfo) AddIPv6(nicId string, address string, networkMask string, r
 			Ipv6Address:             &address,
 			RelatedConnectionPoints: []RelatedConnectionPoint{relationship},
 		}
-		if isNonEmptyValues(networkMask, router) {
+		if checkIfAnyValueIsNonEmpty(networkMask, router) {
 			ipv6.Ipv6NetworkPrefix = &networkMask
 			ipv6.RouterIpv6Address = &router
 		}


### PR DESCRIPTION
### Description

The SDK will return error while adding nameplate if uri-of-product (manufacturer's product-id) is passed as empty string, because it is a required property.


#### Change Type

Please select the relevant options:

- [X] Bug fix (non-breaking change that resolves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

#### Checklist

- [X] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document.
- [X] My changes adhere to the established code style, patterns, and best practices.
- [X] I have added tests that demonstrate the effectiveness of my changes.
- [X] I have updated the documentation accordingly (if applicable).
