### PR TITLE
fix: provide the correct base schema version in context

### DIFF
--- a/model/convert-from-discovered-device.go
+++ b/model/convert-from-discovered-device.go
@@ -9,11 +9,12 @@ package model
 
 import (
 	"fmt"
-	generated "github.com/industrial-asset-hub/asset-link-sdk/v3/generated/iah-discovery"
 	"net/url"
 	"strconv"
 	"strings"
 	"time"
+
+	generated "github.com/industrial-asset-hub/asset-link-sdk/v3/generated/iah-discovery"
 )
 
 const (
@@ -144,12 +145,12 @@ func ConvertFromDiscoveredDevice(device *generated.DiscoveredDevice, expectedTyp
 	DeviceInIahSchema := make(map[string]interface{})
 	DeviceInIahSchema["@type"] = retrieveAssetTypeFromDiscoveredDevice(device)
 	DeviceInIahSchema["@context"] = map[string]interface{}{
-		"base":      "https://common-device-management.code.siemens.io/documentation/asset-modeling/base-schema/v0.7.5/",
+		"base":      baseSchemaInContext,
 		"linkml":    "https://w3id.org/linkml/",
 		"lis":       "http://rds.posccaesar.org/ontology/lis14/rdl/",
 		"schemaorg": "https://schema.org/",
 		"skos":      "http://www.w3.org/2004/02/skos/core#",
-		"@vocab":    "https://common-device-management.code.siemens.io/documentation/asset-modeling/base-schema/v0.7.5/",
+		"@vocab":    baseSchemaInContext,
 	}
 	timestamp := device.Timestamp
 	formattedTimestamp := convertTimestampToRFC339(int64(timestamp))

--- a/model/convert-from-discovered-device_test.go
+++ b/model/convert-from-discovered-device_test.go
@@ -20,7 +20,6 @@ import (
 const fullProfinetSchemaPrefix = "https://schema.industrial-assets.io/profinet/1.0.0/ProfinetDevice#"
 
 func TestDeviceTransformation(t *testing.T) {
-	baseSchema := "https://common-device-management.code.siemens.io/documentation/asset-modeling/base-schema/v0.7.5/"
 	t.Run("ConvertFromDiscoveredDevice when provided a device with identifier value of type text transforms it successfully", func(t *testing.T) {
 		testDeviceForText := &generated.DiscoveredDevice{
 			Identifiers: []*generated.DeviceIdentifier{{
@@ -45,12 +44,12 @@ func TestDeviceTransformation(t *testing.T) {
 				"state_timestamp": convertTimestampToRFC339(1000010000100010),
 			},
 			"@context": map[string]interface{}{
-				"base":      baseSchema,
+				"base":      baseSchemaInContext,
 				"linkml":    "https://w3id.org/linkml/",
 				"lis":       "http://rds.posccaesar.org/ontology/lis14/rdl/",
 				"schemaorg": "https://schema.org/",
 				"skos":      "http://www.w3.org/2004/02/skos/core#",
-				"@vocab":    baseSchema,
+				"@vocab":    baseSchemaInContext,
 			},
 			"product_instance_identifier": map[string]interface{}{
 				"manufacturer_product": map[string]interface{}{
@@ -87,12 +86,12 @@ func TestDeviceTransformation(t *testing.T) {
 				"state_timestamp": convertTimestampToRFC339(1000010000100010),
 			},
 			"@context": map[string]interface{}{
-				"base":      baseSchema,
+				"base":      baseSchemaInContext,
 				"linkml":    "https://w3id.org/linkml/",
 				"lis":       "http://rds.posccaesar.org/ontology/lis14/rdl/",
 				"schemaorg": "https://schema.org/",
 				"skos":      "http://www.w3.org/2004/02/skos/core#",
-				"@vocab":    baseSchema,
+				"@vocab":    baseSchemaInContext,
 			},
 			"test-1": int64(1),
 		}
@@ -122,12 +121,12 @@ func TestDeviceTransformation(t *testing.T) {
 				"state_timestamp": convertTimestampToRFC339(1000010000100010),
 			},
 			"@context": map[string]interface{}{
-				"base":      baseSchema,
+				"base":      baseSchemaInContext,
 				"linkml":    "https://w3id.org/linkml/",
 				"lis":       "http://rds.posccaesar.org/ontology/lis14/rdl/",
 				"schemaorg": "https://schema.org/",
 				"skos":      "http://www.w3.org/2004/02/skos/core#",
-				"@vocab":    baseSchema,
+				"@vocab":    baseSchemaInContext,
 			},
 			"test-2": map[string]interface{}{
 				"A": map[string]interface{}{
@@ -161,12 +160,12 @@ func TestDeviceTransformation(t *testing.T) {
 				"state_timestamp": convertTimestampToRFC339(1000010000100010),
 			},
 			"@context": map[string]interface{}{
-				"base":      baseSchema,
+				"base":      baseSchemaInContext,
 				"linkml":    "https://w3id.org/linkml/",
 				"lis":       "http://rds.posccaesar.org/ontology/lis14/rdl/",
 				"schemaorg": "https://schema.org/",
 				"skos":      "http://www.w3.org/2004/02/skos/core#",
-				"@vocab":    baseSchema,
+				"@vocab":    baseSchemaInContext,
 			},
 			"test-2": map[string]interface{}{
 				"A": map[string]interface{}{
@@ -208,12 +207,12 @@ func TestDeviceTransformation(t *testing.T) {
 		expectedResult := map[string]interface{}{
 			"@type": "ProfinetDevice",
 			"@context": map[string]interface{}{
-				"base":      baseSchema,
+				"base":      baseSchemaInContext,
 				"linkml":    "https://w3id.org/linkml/",
 				"lis":       "http://rds.posccaesar.org/ontology/lis14/rdl/",
 				"schemaorg": "https://schema.org/",
 				"skos":      "http://www.w3.org/2004/02/skos/core#",
-				"@vocab":    baseSchema,
+				"@vocab":    baseSchemaInContext,
 			},
 			"management_state": map[string]interface{}{
 				"state_value":     "unknown",
@@ -287,12 +286,12 @@ func TestDeviceTransformation(t *testing.T) {
 		expectedResult := map[string]interface{}{
 			"@type": "ProfinetDevice",
 			"@context": map[string]interface{}{
-				"base":      baseSchema,
+				"base":      baseSchemaInContext,
 				"linkml":    "https://w3id.org/linkml/",
 				"lis":       "http://rds.posccaesar.org/ontology/lis14/rdl/",
 				"schemaorg": "https://schema.org/",
 				"skos":      "http://www.w3.org/2004/02/skos/core#",
-				"@vocab":    baseSchema,
+				"@vocab":    baseSchemaInContext,
 			},
 			"management_state": map[string]interface{}{
 				"state_value":     "unknown",
@@ -732,7 +731,7 @@ func TestMapManyDeepArrayElementsWithDeepPathsIntoIahDevice(t *testing.T) {
 }
 
 func TestMapManyDeepArrayElementsWithDeepPathsThatContainArraysIntoIahDevice(t *testing.T) {
-	expectedResult := map[string]interface{}{"@context": map[string]interface{}{"@vocab": "https://common-device-management.code.siemens.io/documentation/asset-modeling/base-schema/v0.7.5/", "base": "https://common-device-management.code.siemens.io/documentation/asset-modeling/base-schema/v0.7.5/", "linkml": "https://w3id.org/linkml/", "lis": "http://rds.posccaesar.org/ontology/lis14/rdl/", "schemaorg": "https://schema.org/", "skos": "http://www.w3.org/2004/02/skos/core#"}, "@type": "device", "a": map[string]interface{}{"deeper": map[string]interface{}{"array": []map[string]interface{}{{"some_object": map[string]interface{}{"connection_points": []map[string]interface{}{{"id": "array-0-connection-point-0", "related_connection_points": []map[string]interface{}{{"id": "array-0-con-point-0-related-connection-point-0"}, {"id": "array-0-con-point-0-related-connection-point-1"}}}, {}, {"related_connection_points": []map[string]interface{}{{}, {}, {"id": "array-0-con-point-2-related-connection-point-2"}, {"id": "array-0-con-point-2-related-connection-point-3"}}}}, "name": "array-0-name"}}, {"some_object": map[string]interface{}{"connection_points": []map[string]interface{}{{"id": "array-1-connection-point-0", "related_connection_points": []map[string]interface{}{{"id": "array-1-con-point-0-related-connection-point-0"}, {"id": "array-1-con-point-0-related-connection-point-1"}}}, {"id": "array-1-connection-point-1", "related_connection_points": []map[string]interface{}{{}, {}, {"id": "array-1-con-point-1-related-connection-point-2"}, {"id": "array-1-con-point-1-related-connection-point-3"}}}}, "id": "array-1-id", "name": "array-1-name"}}, {"some_object": map[string]interface{}{"id": "array-2-id"}}}}}, "management_state": map[string]interface{}{"state_timestamp": convertTimestampToRFC339(1000010000100010), "state_value": "unknown"}}
+	expectedResult := map[string]interface{}{"@context": map[string]interface{}{"@vocab": baseSchemaInContext, "base": baseSchemaInContext, "linkml": "https://w3id.org/linkml/", "lis": "http://rds.posccaesar.org/ontology/lis14/rdl/", "schemaorg": "https://schema.org/", "skos": "http://www.w3.org/2004/02/skos/core#"}, "@type": "device", "a": map[string]interface{}{"deeper": map[string]interface{}{"array": []map[string]interface{}{{"some_object": map[string]interface{}{"connection_points": []map[string]interface{}{{"id": "array-0-connection-point-0", "related_connection_points": []map[string]interface{}{{"id": "array-0-con-point-0-related-connection-point-0"}, {"id": "array-0-con-point-0-related-connection-point-1"}}}, {}, {"related_connection_points": []map[string]interface{}{{}, {}, {"id": "array-0-con-point-2-related-connection-point-2"}, {"id": "array-0-con-point-2-related-connection-point-3"}}}}, "name": "array-0-name"}}, {"some_object": map[string]interface{}{"connection_points": []map[string]interface{}{{"id": "array-1-connection-point-0", "related_connection_points": []map[string]interface{}{{"id": "array-1-con-point-0-related-connection-point-0"}, {"id": "array-1-con-point-0-related-connection-point-1"}}}, {"id": "array-1-connection-point-1", "related_connection_points": []map[string]interface{}{{}, {}, {"id": "array-1-con-point-1-related-connection-point-2"}, {"id": "array-1-con-point-1-related-connection-point-3"}}}}, "id": "array-1-id", "name": "array-1-name"}}, {"some_object": map[string]interface{}{"id": "array-2-id"}}}}}, "management_state": map[string]interface{}{"state_timestamp": convertTimestampToRFC339(1000010000100010), "state_value": "unknown"}}
 
 	discoveredDevice := generated.DiscoveredDevice{
 		Identifiers: []*generated.DeviceIdentifier{{

--- a/model/model.go
+++ b/model/model.go
@@ -14,7 +14,9 @@ import (
 )
 
 const (
-	baseSchemaPrefix = "https://schema.industrial-assets.io/base/v0.9.0"
+	baseSchemaVersion   = "v0.9.0"
+	baseSchemaPrefix    = "https://schema.industrial-assets.io/base/" + baseSchemaVersion
+	baseSchemaInContext = "https://common-device-management.code.siemens.io/documentation/asset-modeling/base-schema/" + baseSchemaVersion + "/"
 )
 
 // NewDevice Generates a new asset skeleton


### PR DESCRIPTION
### Description

Provide the correct base schema version in the context (v0.9.0 instead of v0.7.5).

#### Issues Addressed

While these changes were motivated by findings related to issue #63, the PR in its current form will not solve nor address the actual issue but merely provide more consistency.
While the SDK provides a way to convert asset in either direction, the context is actually appended by a downstream component which uses an independent implementation to convert the asset data and which is currently not aware of the schemas used by the asset link during the creation of the asset.
In turn, the schemas stated by the context do not necessarily resemble those that were actually used by the asset link. 
There are already discussions ongoing on how to address this issue.
One way to solve this would be to introduce a reliable way to communicate the involved schemas or context information from the asset link to this component (e.g., via dedicated fields), to adjust the conversion functionality in the SDK to generate the correct context from this data, and to use this conversion functionality of the SDK in downstream components.

#### Change Type

Please select the relevant options:

- [x] Bug fix (non-breaking change that resolves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

#### Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document.
- [x] My changes adhere to the established code style, patterns, and best practices.
- [x] I have added tests that demonstrate the effectiveness of my changes.
- [ ] I have updated the documentation accordingly (if applicable).
