### PR TITLE
Fix/ignored identifier warning received due to unhandled type

### DIFF
--- a/model/convert-to-discovered-device.go
+++ b/model/convert-to-discovered-device.go
@@ -62,14 +62,15 @@ func convertToDeviceIdentifiers(valueToConvert reflect.Value, prefixUri string, 
 			identifiers = appendDeviceIdentifiers(identifiers, structIdentifiers)
 		}
 	case reflect.Slice:
-		if valueToConvert.Len() == 0 {
+		switch {
+		case valueToConvert.Len() == 0:
 			return identifiers
-		} else if valueToConvert.Index(0).Kind() != reflect.Uint8 {
+		case valueToConvert.Index(0).Kind() != reflect.Uint8:
 			for index := 0; index < valueToConvert.Len(); index++ {
 				sliceIdentifier := convertSliceElementToDeviceIdentifier(valueToConvert.Index(index), prefixUri, level+1)
 				identifiers = appendDeviceIdentifiers(identifiers, []*generated.DeviceIdentifier{sliceIdentifier})
 			}
-		} else {
+		default:
 			identifier := convertToDeviceIdentifier(valueToConvert.Interface(), prefixUri)
 			identifiers = appendDeviceIdentifiers(identifiers, []*generated.DeviceIdentifier{identifier})
 		}

--- a/model/convert-to-discovered-device.go
+++ b/model/convert-to-discovered-device.go
@@ -48,8 +48,6 @@ func convertToDeviceIdentifiers(valueToConvert reflect.Value, prefixUri string, 
 	switch valueToConvert.Kind() {
 	case reflect.Ptr:
 		if valueToConvert.IsNil() {
-			productIdentifier := convertToDeviceIdentifier(valueToConvert.Interface(), prefixUri)
-			identifiers = append(identifiers, productIdentifier)
 			return identifiers
 		}
 		structIdentifiers := convertToDeviceIdentifiers(valueToConvert.Elem(), prefixUri, level)
@@ -64,7 +62,9 @@ func convertToDeviceIdentifiers(valueToConvert reflect.Value, prefixUri string, 
 			identifiers = appendDeviceIdentifiers(identifiers, structIdentifiers)
 		}
 	case reflect.Slice:
-		if valueToConvert.Len() > 0 && valueToConvert.Index(0).Kind() != reflect.Uint8 {
+		if valueToConvert.Len() == 0 {
+			return identifiers
+		} else if valueToConvert.Index(0).Kind() != reflect.Uint8 {
 			for index := 0; index < valueToConvert.Len(); index++ {
 				sliceIdentifier := convertSliceElementToDeviceIdentifier(valueToConvert.Index(index), prefixUri, level+1)
 				identifiers = appendDeviceIdentifiers(identifiers, []*generated.DeviceIdentifier{sliceIdentifier})

--- a/model/convert-to-discovered-device_test.go
+++ b/model/convert-to-discovered-device_test.go
@@ -9,6 +9,7 @@ package model
 
 import (
 	"fmt"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -294,6 +295,22 @@ func TestConversionOfAllTypes(t *testing.T) {
 		case "timestamp_pointer":
 			assert.Equal(t, timestampString, extractValue(identifier.String()), "Property: timestamp_pointer")
 		}
+	}
+}
+
+func TestConvertToDeviceIdentifiers_IgnoredIdentifier(t *testing.T) {
+	device := generateDevice("Profinet", "Device")
+	testCases := []struct {
+		fieldValue interface{}
+		uri        string
+	}{
+		{device.ProductInstanceIdentifier.IdentifierUncertainty, "https://schema.industrial-assets.io/base/v0.9.0/Asset#asset_identifiers/identifier_uncertainty"},
+		{device.InstanceAnnotations, "https://schema.industrial-assets.io/base/v0.9.0/Asset#instance_annotations"},
+	}
+
+	for _, testCase := range testCases {
+		identifiers := convertToDeviceIdentifiers(reflect.ValueOf(testCase.fieldValue), testCase.uri, 0)
+		assert.Empty(t, identifiers, fmt.Sprintf("Expected no identifiers for %s", testCase.uri))
 	}
 }
 


### PR DESCRIPTION
### Description

The asset link SDK is generating multiple ignored identifier warnings due to unhandled types.

#### Issues Addressed

Ignored identifier warning received due to unhandled type in Asset Link SDK

#### Change Type

Please select the relevant options:

- [x] Bug fix (non-breaking change that resolves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

#### Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document.
- [x] My changes adhere to the established code style, patterns, and best practices.
- [x] I have added tests that demonstrate the effectiveness of my changes.
- [x] I have updated the documentation accordingly (if applicable).
