### PR TITLE
fix: adjust AddSoftware() and add support for firmware version

### DIFF
--- a/cdm-al-reference/reference/reference.go
+++ b/cdm-al-reference/reference/reference.go
@@ -60,7 +60,7 @@ func (m *ReferenceAssetLink) Discover(discoveryConfig config.DiscoveryConfig, de
 		nicID := deviceInfo.AddNic(device.GetDeviceNIC(), device.GetMacAddress())
 		deviceInfo.AddIPv4(nicID, device.GetIpDevice(), device.GetIpNetmask(), device.GetIpRoute())
 
-		deviceInfo.AddSoftware("firmware", device.GetFirmwareVersion())
+		deviceInfo.AddSoftware("Firmware", device.GetFirmwareVersion(), true)
 		deviceInfo.AddCapabilities("firmware_update", device.IsUpdateSupported())
 
 		discoveredDevice := deviceInfo.ConvertToDiscoveredDevice()

--- a/cookiecutter-project-template/{{ cookiecutter.al_project }}/handler/handler.go
+++ b/cookiecutter-project-template/{{ cookiecutter.al_project }}/handler/handler.go
@@ -72,7 +72,7 @@ func (m *AssetLinkImplementation) Discover(discoveryConfig config.DiscoveryConfi
 
 	deviceInfo := model.NewDevice("EthernetDevice", assetName)
 	deviceInfo.AddNameplate(vendorName, productUri, orderNumber, productName, hardwareVersion, serialNumber)
-	deviceInfo.AddSoftware("firmware", firmwareVersion)
+	deviceInfo.AddSoftware("Firmware", firmwareVersion, true)
 	deviceInfo.AddCapabilities("firmware_update", false)
 
 	nicID := deviceInfo.AddNic("eth0", "00:16:3e:01:02:03") // random mac address

--- a/model/nameplate.go
+++ b/model/nameplate.go
@@ -10,6 +10,7 @@ package model
 import (
 	"crypto/sha1"
 	"encoding/hex"
+
 	"github.com/google/uuid"
 )
 
@@ -30,7 +31,6 @@ func (d *DeviceInfo) AddNameplate(manufacturerName string,
 	hardwareVersion string,
 	serialNumber string,
 ) {
-
 	if isNonEmptyValues(manufacturerName, uriOfTheProduct, productArticleNumberOfManufacturer, manufacturerProductDesignation, hardwareVersion, serialNumber) {
 
 		// We hash the manufacturer to get a unique identifier
@@ -76,58 +76,38 @@ func (d *DeviceInfo) AddNameplate(manufacturerName string,
 }
 
 // AddSoftware Add software information to an asset
-func (d *DeviceInfo) AddSoftware(name string, version string) {
-	softwareIdentifier := SoftwareIdentifier{}
-	runningSoftwareId := uuid.New().String()
-	softwareArtifactId := uuid.New().String()
+func (d *DeviceInfo) AddSoftware(name string, version string, isFirmware bool) {
 	if isNonEmptyValues(name, version) {
+		softwareIdentifier := SoftwareIdentifier{}
 		softwareIdentifier.Name = &name
 		softwareIdentifier.Version = &version
-	}
 
-	stateValue := ManagementStateValuesRegarded
-	stateTimestamp := d.getAssetCreationTimestamp()
+		softwareArtifactId := uuid.New().String()
 
-	softwareArtifact := SoftwareArtifact{
-		AssetOperations:     nil,
-		ChecksumIdentifier:  nil,
-		ConnectionPoints:    nil,
-		CustomUiProperties:  nil,
-		FunctionalParts:     nil,
-		Id:                  softwareArtifactId,
-		InstanceAnnotations: nil,
-		ManagementState: ManagementState{
-			StateTimestamp: &stateTimestamp,
-			StateValue:     &stateValue,
-		},
-		Name:                      nil,
-		OtherStates:               nil,
-		ProductInstanceIdentifier: nil,
-		ReachabilityState:         nil,
-		SoftwareComponents:        nil,
-		SoftwareIdentifier:        &softwareIdentifier,
-	}
-	runningSoftware := RunningSoftware{
-		Artifact:                  &softwareArtifact,
-		AssetOperations:           nil,
-		ConnectionPoints:          nil,
-		CustomRunningSoftwareType: nil,
-		CustomUiProperties:        nil,
-		FunctionalParts:           nil,
-		Id:                        runningSoftwareId,
-		InstanceAnnotations:       nil,
-		ManagementState: ManagementState{
-			StateTimestamp: &stateTimestamp,
-			StateValue:     &stateValue,
-		},
-		Name:                      nil,
-		OtherStates:               nil,
-		ProductInstanceIdentifier: nil,
-		ReachabilityState:         nil,
-		RunningSoftwareType:       nil,
-		RunningSwId:               nil,
-		SoftwareComponents:        nil,
-	}
+		stateValue := ManagementStateValuesRegarded
+		stateTimestamp := d.getAssetCreationTimestamp()
 
-	d.SoftwareComponents = append(d.SoftwareComponents, runningSoftware)
+		softwareArtifact := SoftwareArtifact{
+			Id:                  softwareArtifactId,
+			AssetOperations:     nil,
+			ChecksumIdentifier:  nil,
+			ConnectionPoints:    nil,
+			CustomUiProperties:  nil,
+			FunctionalParts:     nil,
+			InstanceAnnotations: nil,
+			ManagementState: ManagementState{
+				StateTimestamp: &stateTimestamp,
+				StateValue:     &stateValue,
+			},
+			Name:                      nil,
+			OtherStates:               nil,
+			ProductInstanceIdentifier: nil,
+			ReachabilityState:         nil,
+			SoftwareComponents:        nil,
+			SoftwareIdentifier:        &softwareIdentifier,
+			IsFirmware:                &isFirmware,
+		}
+
+		d.SoftwareComponents = append(d.SoftwareComponents, softwareArtifact)
+	}
 }


### PR DESCRIPTION
### Description

This PR fixes issues with the model's `AddSoftware()` function.
Instead of adding the corresponding software component as `RunningSoftware` (that references a `SoftwareArtifact`) it now directly adds a `SoftwareArtifact`.
Moreover, adding a software with the name "firmware" will now correctly set the `is_firmware` flag and therefore allow the firmware version to show up in recent versions of IAH.

#### Issues Addressed

Fixes Issue #94 

#### Change Type

Please select the relevant options:

- [ ] Bug fix (non-breaking change that resolves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

#### Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document.
- [x] My changes adhere to the established code style, patterns, and best practices.
- [x] I have added tests that demonstrate the effectiveness of my changes.
- [ ] I have updated the documentation accordingly (if applicable).
