### PR TITLE
fix: adding specific parameter null check for convenience method

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/industrial-asset-hub/asset-link-sdk/v3
 
-go 1.24.5
+go 1.23.0
 
 toolchain go1.24.1
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/industrial-asset-hub/asset-link-sdk/v3
 
-go 1.23.0
+go 1.24.5
 
 toolchain go1.24.1
 

--- a/model/network.go
+++ b/model/network.go
@@ -52,7 +52,7 @@ func (d *DeviceInfo) AddNic(name string, macAddress string) (nicId string) {
 // No validation of is currently done
 func (d *DeviceInfo) AddIPv4(nicId string, address string, networkMask string, router string) (id string) {
 
-	if isNonEmptyValues(address) {
+	if isNonEmptyValues(address, networkMask, router) {
 		id = uuid.New().String()
 
 		t := Ipv4ConnectivityConnectionPointTypeIpv4Connectivity

--- a/model/network_test.go
+++ b/model/network_test.go
@@ -56,10 +56,13 @@ func TestNetwork(t *testing.T) {
 		assert.NotEmpty(t, m.AddIPv4("nic99",
 			"172.16.0.1", "255.255.255.0",
 			""))
+		assert.Empty(t, m.AddIPv4("nic101",
+			"", "",
+			""))
 
 		addresses := m.getIPv4()
 		if len(addresses) != 2 {
-			fmt.Printf("Expected 1 address, got %d\n", len(addresses))
+			fmt.Printf("Expected 2 address, got %d\n", len(addresses))
 			t.Fail()
 		}
 		found := 0


### PR DESCRIPTION
### Description

Added specific null check for parameters for convenience methods. 

#### Issues Addressed

- Ipv4connection point can be created with any of the present values
- Product instance identifier can be created with any of the present values.

#### Change Type

Please select the relevant options:

- [ ] Bug fix (non-breaking change that resolves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

#### Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document.
- [x] My changes adhere to the established code style, patterns, and best practices.
- [x] I have added tests that demonstrate the effectiveness of my changes.
- [x] I have updated the documentation accordingly (if applicable).
