### PR TITLE
feat: make discovery of simulated devices a two-step process

### DIFF
--- a/cdm-al-reference/simdevices/simdevices_test.go
+++ b/cdm-al-reference/simdevices/simdevices_test.go
@@ -1,0 +1,48 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Siemens AG
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ */
+
+package simdevices
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSimDevices(t *testing.T) {
+	StartSimulatedDevices("") // start without visualization web server
+
+	t.Run("discoveryWithCredentials", func(t *testing.T) {
+		deviceAddresses := ScanForDevices("", "") // scan without filters
+		assert.Len(t, deviceAddresses, 6)
+
+		for _, addr := range deviceAddresses {
+			device, err := RetrieveDeviceDetails(addr, "admin", "admin") // use correct credentials
+			assert.NoError(t, err)
+			assert.NotNil(t, device)
+		}
+	})
+
+	t.Run("discoveryWithoutCredentials", func(t *testing.T) {
+		deviceAddresses := ScanForDevices("", "") // scan without filters
+		assert.Len(t, deviceAddresses, 6)
+
+		failed := 0
+		successful := 0
+		for _, addr := range deviceAddresses {
+			device, err := RetrieveDeviceDetails(addr, "", "") // do not use credentials
+			if err != nil || device == nil {
+				failed++
+			} else {
+				successful++
+			}
+		}
+
+		assert.Equal(t, 4, successful)
+		assert.Equal(t, 2, failed)
+	})
+}

--- a/cookiecutter-project-template/{{ cookiecutter.al_project }}/handler/handler.go
+++ b/cookiecutter-project-template/{{ cookiecutter.al_project }}/handler/handler.go
@@ -74,6 +74,7 @@ func (m *AssetLinkImplementation) Discover(discoveryConfig config.DiscoveryConfi
 	deviceInfo.AddNameplate(vendorName, productUri, orderNumber, productName, hardwareVersion, serialNumber)
 	deviceInfo.AddSoftware("Firmware", firmwareVersion, true)
 	deviceInfo.AddCapabilities("firmware_update", false)
+	deviceInfo.AddDescription("Dummy Device")
 
 	nicID := deviceInfo.AddNic("eth0", "00:16:3e:01:02:03") // random mac address
 	deviceInfo.AddIPv4(nicID, "192.168.0.10", "255.255.255.0", "")


### PR DESCRIPTION
- discovery of simulated devices now consists of the scan for devices and the retrieval of their device details
- simulated devices may now require credentials before their details can be retrieved (and this step can thus fail)
- add some tests for the simulated devices

### Description

Please provide a concise summary of the changes and their motivation.

#### Issues Addressed

List and link all the issues addressed by this PR.

#### Change Type

Please select the relevant options:

- [ ] Bug fix (non-breaking change that resolves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

#### Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document.
- [x] My changes adhere to the established code style, patterns, and best practices.
- [x] I have added tests that demonstrate the effectiveness of my changes.
- [ ] I have updated the documentation accordingly (if applicable).
