### PR TITLE
fix: change discovery timeout to float64

### DIFF
--- a/cmd/al-ctl/cmd/root.go
+++ b/cmd/al-ctl/cmd/root.go
@@ -60,7 +60,7 @@ func init() {
 			zerolog.ErrorLevel.String(),
 			zerolog.FatalLevel.String(),
 			zerolog.PanicLevel.String()))
-	rootCmd.PersistentFlags().UintVarP(&shared.TimeoutSeconds, "timeout", "n", 0, "timeout in seconds (default none)")
+	rootCmd.PersistentFlags().Float64VarP(&shared.TimeoutSeconds, "timeout", "n", 0, "timeout in seconds (default none), accepts float values (e.g., 0.5, 1.5)")
 	rootCmd.AddCommand(assets.AssetsCmd)
 	rootCmd.AddCommand(info.InfoCmd)
 	rootCmd.AddCommand(registry.ListCmd)

--- a/cmd/al-ctl/internal/al/discovery.go
+++ b/cmd/al-ctl/internal/al/discovery.go
@@ -48,7 +48,8 @@ func Discover(endpoint string, discoveryFile string) ([]*generated.DiscoverRespo
 		var cancel context.CancelFunc
 		ctx, cancel = context.WithCancel(ctx)
 		go func() {
-			time.Sleep(time.Duration(shared.TimeoutSeconds) * time.Second)
+			duration := time.Duration(shared.TimeoutSeconds * float64(time.Second))
+			time.Sleep(duration)
 			cancel()
 		}()
 	}

--- a/cmd/al-ctl/internal/shared/shared.go
+++ b/cmd/al-ctl/internal/shared/shared.go
@@ -11,7 +11,7 @@ var (
 	RegistryEndpoint  string
 	AssetLinkEndpoint string
 
-	TimeoutSeconds uint
+	TimeoutSeconds float64
 )
 
 const (

--- a/docs/cmd.md
+++ b/docs/cmd.md
@@ -94,7 +94,7 @@ $ al-ctl test api -l -e localhost:8081 --service-name discovery -v --base-schema
 ```bash
 # To also validate the cancellation of the discovery use -c flag
 $ al-ctl test api -e localhost:8081 --service-name discovery [-d <discovery-config>] -c -n <timeout>
-# Timeout is the delay until the discovery is cancelled automatically
+# Timeout is the delay until the discovery is cancelled automatically. Timeout value can be given as a float value.
 ```
 
 ```bash


### PR DESCRIPTION
### Description

Updated the discovery timeout data type to float64 to support millisecond-level precision, as discovery cancellation operates in milliseconds and the timeout previously accepted only integer values.

#### Issues Addressed

Discovery cancellation using al-ctl could not be executed because the discovery process completed in milliseconds.

#### Change Type

Please select the relevant options:

- [x] Bug fix (non-breaking change that resolves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

#### Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document.
- [x] My changes adhere to the established code style, patterns, and best practices.
- [ ] I have added tests that demonstrate the effectiveness of my changes.
- [ ] I have updated the documentation accordingly (if applicable).
