### PR TITLE
fix: remove duplicate caller field for json logs

### DIFF
--- a/logging/logging.go
+++ b/logging/logging.go
@@ -31,7 +31,7 @@ func SetupLogging() {
 	}
 	switch format {
 	case "json":
-		logger = zerolog.New(out).With().Caller().Logger()
+		logger = zerolog.New(out)
 	case "pretty":
 		logger = zerolog.New(zerolog.ConsoleWriter{
 			Out:        out,


### PR DESCRIPTION
### Description

Removed duplicate "caller" field for an asset link when format is set to JSON log

#### Issues Addressed

Below are the steps to reproduce this issue:
1. Create an Asset link using Asset Link SDK v3.6.2
2. Call logging.SetupLogging() method to configure zerolog global logger.
3. Add log statement to the Asset Link Created
4. Run Asset Link so that format is Set to JSON log.
5. Check logs, JSON log will have two "caller" fields

#### Change Type

Please select the relevant options:

- [x] Bug fix (non-breaking change that resolves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

#### Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document.
- [x] My changes adhere to the established code style, patterns, and best practices.
- [ ] I have added tests that demonstrate the effectiveness of my changes.
- [ ] I have updated the documentation accordingly (if applicable).
