### PR TITLE
Fix/ipv4 error handling

### DIFF
--- a/model/nameplate.go
+++ b/model/nameplate.go
@@ -37,6 +37,20 @@ func (d *DeviceInfo) AddNameplate(manufacturerName string,
 		return err
 	}
 
+	// We hash the manufacturer to get a unique identifier
+	h := sha1.New()
+	h.Write([]byte(manufacturerName))
+
+	organisation := Organization{
+		Name: &manufacturerName,
+	}
+	mp := Product{
+		Manufacturer:   &organisation,
+		ProductId:      &productArticleNumberOfManufacturer,
+		ProductVersion: &hardwareVersion,
+		ProductFamily:  &productFamily,
+	}
+
 	if isNonEmptyValues(uriOfTheProduct) {
 		if !validateByPattern(uriOfTheProduct, IdLinkPattern) {
 			return &ValidationError{
@@ -46,21 +60,7 @@ func (d *DeviceInfo) AddNameplate(manufacturerName string,
 				Details: uriOfTheProduct,
 			}
 		}
-	}
-
-	// We hash the manufacturer to get a unique identifier
-	h := sha1.New()
-	h.Write([]byte(manufacturerName))
-
-	organisation := Organization{
-		Name: &manufacturerName,
-	}
-	mp := Product{
-		ProductLink:    &uriOfTheProduct,
-		Manufacturer:   &organisation,
-		ProductId:      &productArticleNumberOfManufacturer,
-		ProductVersion: &hardwareVersion,
-		ProductFamily:  &productFamily,
+		mp.ProductLink = &uriOfTheProduct
 	}
 
 	d.ProductInstanceInformation = &ProductInstanceInformation{

--- a/model/nameplate_test.go
+++ b/model/nameplate_test.go
@@ -104,9 +104,7 @@ func TestNameplate(t *testing.T) {
 		if assert.True(t, ok) {
 			manufacturerProduct, ok := productInfo.ManufacturerProduct.(*Product)
 			if assert.True(t, ok) {
-				if assert.NotNil(t, manufacturerProduct.ProductLink) {
-					assert.Equal(t, "", *manufacturerProduct.ProductLink)
-				}
+				assert.Nil(t, manufacturerProduct.ProductLink) // no product link set when idLink is empty
 			}
 		}
 

--- a/model/network.go
+++ b/model/network.go
@@ -9,6 +9,7 @@ package model
 
 import (
 	"github.com/google/uuid"
+	"github.com/rs/zerolog/log"
 )
 
 // AddNic Add a network interface card
@@ -55,11 +56,6 @@ func (d *DeviceInfo) AddIPv4(nicId string, ipv4Address string, networkMask strin
 	if err != nil {
 		return "", err
 	}
-	err = validateField(routerAddress, "RouterIPv4Address", "Router IPv4 address is empty", RouterIPv4AddressPattern,
-		"Router IPv4 address format is invalid. Please refer to the base schema for the supported pattern.")
-	if err != nil {
-		return "", err
-	}
 
 	id = uuid.New().String()
 	connectionPointType := Ipv4ConnectivityConnectionPointTypeIpv4Connectivity
@@ -75,7 +71,13 @@ func (d *DeviceInfo) AddIPv4(nicId string, ipv4Address string, networkMask strin
 		RelatedConnectionPoints: []RelatedConnectionPoint{relationship},
 	}
 	ipv4.NetworkMask = &networkMask
-	ipv4.RouterIpv4Address = &routerAddress
+	err = validateField(routerAddress, "RouterIPv4Address", "Router IPv4 address is empty", RouterIPv4AddressPattern,
+		"Router IPv4 address format is invalid. Please refer to the base schema for the supported pattern.")
+	if err != nil {
+		log.Warn().Err(err).Str("field", "RouterIPv4Address").Msg("Ignoring router IPv4 address")
+	} else {
+		ipv4.RouterIpv4Address = &routerAddress
+	}
 	d.ConnectionPoints = append(d.ConnectionPoints, ipv4)
 
 	return id, nil
@@ -90,10 +92,6 @@ func (d *DeviceInfo) AddIPv6(nicId string, ipv6Address string, networkPrefix str
 		return "", err
 	}
 	err = validateField(networkPrefix, "IPv6NetworkPrefix", "IPv6 network prefix is empty", IPv6NetworkPrefixPattern, "IPv6 network prefix format is invalid. Please refer to the base schema for the supported pattern.")
-	if err != nil {
-		return "", err
-	}
-	err = validateField(routerAddress, "RouterIPv6Address", "Router IPv6 address is empty", RouterIPv6AddressPattern, "Router IPv6 address format is invalid. Please refer to the base schema for the supported pattern.")
 	if err != nil {
 		return "", err
 	}
@@ -112,7 +110,12 @@ func (d *DeviceInfo) AddIPv6(nicId string, ipv6Address string, networkPrefix str
 		RelatedConnectionPoints: []RelatedConnectionPoint{relationship},
 	}
 	ipv6.Ipv6NetworkPrefix = &networkPrefix
-	ipv6.RouterIpv6Address = &routerAddress
+	err = validateField(routerAddress, "RouterIPv6Address", "Router IPv6 address is empty", RouterIPv6AddressPattern, "Router IPv6 address format is invalid. Please refer to the base schema for the supported pattern.")
+	if err != nil {
+		log.Warn().Err(err).Str("field", "RouterIPv6Address").Msg("Ignoring router IPv6 address")
+	} else {
+		ipv6.RouterIpv6Address = &routerAddress
+	}
 	d.ConnectionPoints = append(d.ConnectionPoints, ipv6)
 
 	return id, nil

--- a/model/network.go
+++ b/model/network.go
@@ -47,7 +47,11 @@ func (d *DeviceInfo) AddNic(name, macAddress string) (string, error) {
 // No validation of is currently done
 func (d *DeviceInfo) AddIPv4(nicId string, ipv4Address string, networkMask string, routerAddress string) (id string, err error) {
 	if !isNonEmptyValues(ipv4Address, networkMask, routerAddress) {
-		return "", nil
+		err := &EmptyError{
+			Field:   "Ipv4Connectivity",
+			Message: "All fields for Ipv4Connectivity are empty",
+		}
+		return "", err
 	}
 
 	id = uuid.New().String()
@@ -96,7 +100,11 @@ func (d *DeviceInfo) AddIPv4(nicId string, ipv4Address string, networkMask strin
 // No validation of is currently done
 func (d *DeviceInfo) AddIPv6(nicId string, ipv6Address string, networkPrefix string, routerAddress string) (id string, err error) {
 	if !isNonEmptyValues(ipv6Address, networkPrefix, routerAddress) {
-		return "", nil
+		err := &EmptyError{
+			Field:   "Ipv6Connectivity",
+			Message: "All fields for Ipv6Connectivity are empty",
+		}
+		return "", err
 	}
 
 	id = uuid.New().String()

--- a/model/network.go
+++ b/model/network.go
@@ -46,15 +46,8 @@ func (d *DeviceInfo) AddNic(name, macAddress string) (string, error) {
 //
 // No validation of is currently done
 func (d *DeviceInfo) AddIPv4(nicId string, ipv4Address string, networkMask string, routerAddress string) (id string, err error) {
-	err = validateField(ipv4Address, "IPv4Address", "IPv4 address is empty", IPv4AddressPattern,
-		"IPv4 address format is invalid. Please refer to the base schema for the supported pattern.")
-	if err != nil {
-		return "", err
-	}
-	err = validateField(networkMask, "NetworkMask", "Network mask is empty", NetworkMaskPattern,
-		"Network mask format is invalid. Please refer to the base schema for the supported pattern.")
-	if err != nil {
-		return "", err
+	if !isNonEmptyValues(ipv4Address, networkMask, routerAddress) {
+		return "", nil
 	}
 
 	id = uuid.New().String()
@@ -67,10 +60,25 @@ func (d *DeviceInfo) AddIPv4(nicId string, ipv4Address string, networkMask strin
 	ipv4 := Ipv4Connectivity{
 		ConnectionPointType:     connectionPointType,
 		Id:                      &id,
-		Ipv4Address:             ipv4Address,
 		RelatedConnectionPoints: []RelatedConnectionPoint{relationship},
 	}
-	ipv4.NetworkMask = &networkMask
+
+	err = validateField(ipv4Address, "IPv4Address", "IPv4 address is empty", IPv4AddressPattern,
+		"IPv4 address format is invalid. Please refer to the base schema for the supported pattern.")
+	if err != nil {
+		log.Warn().Err(err).Str("field", "IPv4Address").Msg("Ignoring IPv4 address")
+	} else {
+		ipv4.Ipv4Address = ipv4Address
+	}
+
+	err = validateField(networkMask, "NetworkMask", "Network mask is empty", NetworkMaskPattern,
+		"Network mask format is invalid. Please refer to the base schema for the supported pattern.")
+	if err != nil {
+		log.Warn().Err(err).Str("field", "NetworkMask").Msg("Ignoring network mask")
+	} else {
+		ipv4.NetworkMask = &networkMask
+	}
+
 	err = validateField(routerAddress, "RouterIPv4Address", "Router IPv4 address is empty", RouterIPv4AddressPattern,
 		"Router IPv4 address format is invalid. Please refer to the base schema for the supported pattern.")
 	if err != nil {
@@ -87,13 +95,8 @@ func (d *DeviceInfo) AddIPv4(nicId string, ipv4Address string, networkMask strin
 //
 // No validation of is currently done
 func (d *DeviceInfo) AddIPv6(nicId string, ipv6Address string, networkPrefix string, routerAddress string) (id string, err error) {
-	err = validateField(ipv6Address, "IPv6Address", "IPv6 address is empty", IPv6AddressPattern, "IPv6 address format is invalid. Please refer to the base schema for the supported pattern.")
-	if err != nil {
-		return "", err
-	}
-	err = validateField(networkPrefix, "IPv6NetworkPrefix", "IPv6 network prefix is empty", IPv6NetworkPrefixPattern, "IPv6 network prefix format is invalid. Please refer to the base schema for the supported pattern.")
-	if err != nil {
-		return "", err
+	if !isNonEmptyValues(ipv6Address, networkPrefix, routerAddress) {
+		return "", nil
 	}
 
 	id = uuid.New().String()
@@ -106,10 +109,23 @@ func (d *DeviceInfo) AddIPv6(nicId string, ipv6Address string, networkPrefix str
 	ipv6 := Ipv6Connectivity{
 		ConnectionPointType:     connectionPointType,
 		Id:                      &id,
-		Ipv6Address:             ipv6Address,
 		RelatedConnectionPoints: []RelatedConnectionPoint{relationship},
 	}
-	ipv6.Ipv6NetworkPrefix = &networkPrefix
+
+	err = validateField(ipv6Address, "IPv6Address", "IPv6 address is empty", IPv6AddressPattern, "IPv6 address format is invalid. Please refer to the base schema for the supported pattern.")
+	if err != nil {
+		log.Warn().Err(err).Str("field", "IPv6Address").Msg("Ignoring IPv6 address")
+	} else {
+		ipv6.Ipv6Address = ipv6Address
+	}
+
+	err = validateField(networkPrefix, "IPv6NetworkPrefix", "IPv6 network prefix is empty", IPv6NetworkPrefixPattern, "IPv6 network prefix format is invalid. Please refer to the base schema for the supported pattern.")
+	if err != nil {
+		log.Warn().Err(err).Str("field", "IPv6NetworkPrefix").Msg("Ignoring IPv6 network prefix")
+	} else {
+		ipv6.Ipv6NetworkPrefix = &networkPrefix
+	}
+
 	err = validateField(routerAddress, "RouterIPv6Address", "Router IPv6 address is empty", RouterIPv6AddressPattern, "Router IPv6 address format is invalid. Please refer to the base schema for the supported pattern.")
 	if err != nil {
 		log.Warn().Err(err).Str("field", "RouterIPv6Address").Msg("Ignoring router IPv6 address")

--- a/model/network_test.go
+++ b/model/network_test.go
@@ -61,37 +61,30 @@ func TestNetwork(t *testing.T) {
 		assert.NotEmpty(t, id)
 		assert.NoError(t, err)
 
-		id, err = m.AddIPv4("nic0", "172.16.0.1", "", "")
-		assert.Empty(t, id)
-		assert.Error(t, err)
+		id, err = m.AddIPv4("nic1", "172.16.0.1", "", "")
+		assert.NotEmpty(t, id)
+		assert.NoError(t, err)
+		cp := m.findIPv4(id)
+		assert.NotNil(t, cp)
+		assert.Equal(t, "172.16.0.1", cp.Ipv4Address)
+		assert.Nil(t, cp.NetworkMask)
+		assert.Nil(t, cp.RouterIpv4Address)
 
 		id, err = m.AddIPv4("nic101", "", "", "")
 		assert.Empty(t, id)
-		assert.Error(t, err)
-		var ee *EmptyError
-		if errors.As(err, &ee) {
-			assert.Equal(t, "IPv4Address", ee.Field)
-			assert.Equal(t, "IPv4 address is empty", ee.Message)
-			assert.Equal(t, "", ee.Value)
-		}
+		assert.NoError(t, err)
 
 		id, err = m.AddIPv4("nic102", "999.999.999.999", "255.255.255.0", "10.0.0.254")
-		assert.Empty(t, id)
-		assert.Error(t, err)
-		var ve *ValidationError
-		if errors.As(err, &ve) {
-			assert.Equal(t, "IPv4Address", ve.Field)
-			assert.Equal(t, "IPv4 address format is invalid. Please refer to the base schema for the supported pattern.", ve.Message)
-			assert.Equal(t, "999.999.999.999", ve.Value)
-		}
+		assert.NotEmpty(t, id)
+		assert.NoError(t, err)
+		cp = m.findIPv4(id)
+		assert.NotNil(t, cp)
+		assert.Equal(t, "", cp.Ipv4Address)
+		assert.Equal(t, "255.255.255.0", *cp.NetworkMask)
+		assert.Equal(t, "10.0.0.254", *cp.RouterIpv4Address)
 
-		addresses := m.getIPv4()
-		if len(addresses) != 1 {
-			fmt.Printf("Expected 1 address, got %d\n", len(addresses))
-			t.Fail()
-		}
 		found := 0
-		for _, v := range addresses {
+		for _, v := range m.getIPv4() {
 			for _, ik := range v.RelatedConnectionPoints {
 				if ik.ConnectionPointId == "nic0" {
 					found++
@@ -114,16 +107,16 @@ func TestNetwork(t *testing.T) {
 		assert.NotEmpty(t, id1)
 
 		id2, err2 := m.AddIPv6("nic2", "2001:0db8:85a3:0000:0000:8a2e:0370:7334", "", "")
-		assert.Error(t, err2)
-		assert.Empty(t, id2)
+		assert.NoError(t, err2)
+		assert.NotEmpty(t, id2)
+		cp := m.findIPv6(id2)
+		assert.NotNil(t, cp)
+		assert.Equal(t, "2001:0db8:85a3:0000:0000:8a2e:0370:7334", cp.Ipv6Address)
+		assert.Nil(t, cp.Ipv6NetworkPrefix)
+		assert.Nil(t, cp.RouterIpv6Address)
 
-		addresses := m.getIPv6()
-		if len(addresses) != 1 {
-			fmt.Printf("Expected 1 address, got %d\n", len(addresses))
-			t.Fail()
-		}
 		found := 0
-		for _, v := range addresses {
+		for _, v := range m.getIPv6() {
 			for _, ik := range v.RelatedConnectionPoints {
 				if ik.ConnectionPointId == "nic0" {
 					found++
@@ -207,46 +200,42 @@ func TestAddIPv6_Validation(t *testing.T) {
 		assert.NotEmpty(t, id)
 	})
 
-	t.Run("Empty IPv6 address should return EmptyError", func(t *testing.T) {
-		id, err := m.AddIPv6(nicId, "", "/64", "2001:0db8:85a3:0000:0000:8a2e:0370:7334")
-		assert.Empty(t, id)
-		assert.Error(t, err)
-		var ee *EmptyError
-		if errors.As(err, &ee) {
-			assert.Equal(t, "IPv6Address", ee.Field)
-			assert.Equal(t, "IPv6 address is empty", ee.Message)
-			assert.Equal(t, "", ee.Value)
-		}
+	t.Run("Empty IPv6 address is ignored with warning", func(t *testing.T) {
+		id, err := m.AddIPv6(nicId, "", "2001:db8:/64", "2001:0db8:85a3:0000:0000:8a2e:0370:7334")
+		assert.NotEmpty(t, id)
+		assert.NoError(t, err)
+		cp := m.findIPv6(id)
+		assert.NotNil(t, cp)
+		assert.Equal(t, "", cp.Ipv6Address)
+		assert.Equal(t, "2001:db8:/64", *cp.Ipv6NetworkPrefix)
+		assert.Equal(t, "2001:0db8:85a3:0000:0000:8a2e:0370:7334", *cp.RouterIpv6Address)
 	})
 
-	t.Run("Invalid IPv6 address format should return ValidationError", func(t *testing.T) {
-		id, err := m.AddIPv6(nicId, "invalid-ipv6", "2001:0db8:85a3:0000:0000:8a2e:0370:7334/64", "2001:0db8:85a3:0000:0000:8a2e:0370:7334")
-		assert.Empty(t, id)
-		assert.Error(t, err)
-		var ve *ValidationError
-		if errors.As(err, &ve) {
-			assert.Equal(t, "IPv6Address", ve.Field)
-			assert.Equal(t, "IPv6 address format is invalid. Please refer to the base schema for the supported pattern.", ve.Message)
-			assert.Equal(t, "invalid-ipv6", ve.Value)
-		}
+	t.Run("Invalid IPv6 address format is ignored with warning", func(t *testing.T) {
+		id, err := m.AddIPv6(nicId, "invalid-ipv6", "2001:db8:/64", "2001:0db8:85a3:0000:0000:8a2e:0370:7334")
+		assert.NotEmpty(t, id)
+		assert.NoError(t, err)
+		cp := m.findIPv6(id)
+		assert.NotNil(t, cp)
+		assert.Equal(t, "", cp.Ipv6Address)
 	})
 
-	t.Run("Invalid IPv6 network prefix should return ValidationError", func(t *testing.T) {
+	t.Run("Invalid IPv6 network prefix is ignored with warning", func(t *testing.T) {
 		id, err := m.AddIPv6(nicId, "2001:0db8:85a3:0000:0000:8a2e:0370:7334", "invalid-prefix", "2001:0db8:85a3:0000:0000:8a2e:0370:7334")
-		assert.Empty(t, id)
-		assert.Error(t, err)
-		var ve *ValidationError
-		if errors.As(err, &ve) {
-			assert.Equal(t, "IPv6NetworkPrefix", ve.Field)
-			assert.Equal(t, "IPv6 network prefix format is invalid. Please refer to the base schema for the supported pattern.", ve.Message)
-			assert.Equal(t, "invalid-prefix", ve.Value)
-		}
+		assert.NotEmpty(t, id)
+		assert.NoError(t, err)
+		cp := m.findIPv6(id)
+		assert.NotNil(t, cp)
+		assert.Nil(t, cp.Ipv6NetworkPrefix)
 	})
 
 	t.Run("Invalid router IPv6 address should be ignored with warning", func(t *testing.T) {
 		id, err := m.AddIPv6(nicId, "2001:0db8:85a3:0000:0000:8a2e:0370:7334", "2001:db8:/64", "invalid-router")
 		assert.NotEmpty(t, id)
 		assert.NoError(t, err)
+		cp := m.findIPv6(id)
+		assert.NotNil(t, cp)
+		assert.Nil(t, cp.RouterIpv6Address)
 	})
 }
 
@@ -260,16 +249,15 @@ func TestAddIPv4_ZeroAddressValues(t *testing.T) {
 		assert.NotEmpty(t, id)
 	})
 
-	t.Run("Network mask 0.0.0.0 should return ValidationError", func(t *testing.T) {
+	t.Run("Network mask 0.0.0.0 is ignored with warning", func(t *testing.T) {
 		id, err := m.AddIPv4("nic0", "10.0.0.1", "0.0.0.0", "10.0.0.254")
-		assert.Empty(t, id)
-		assert.Error(t, err)
-		var ve *ValidationError
-		if errors.As(err, &ve) {
-			assert.Equal(t, "NetworkMask", ve.Field)
-			assert.Equal(t, "Network mask format is invalid. Please refer to the base schema for the supported pattern.", ve.Message)
-			assert.Equal(t, "0.0.0.0", ve.Value)
-		}
+		assert.NotEmpty(t, id)
+		assert.NoError(t, err)
+		cp := m.findIPv4(id)
+		assert.NotNil(t, cp)
+		assert.Equal(t, "10.0.0.1", cp.Ipv4Address)
+		assert.Nil(t, cp.NetworkMask)
+		assert.Equal(t, "10.0.0.254", *cp.RouterIpv4Address)
 	})
 
 	t.Run("Gateway router 0.0.0.0 should succeed", func(t *testing.T) {
@@ -311,4 +299,24 @@ func (d *DeviceInfo) getIPv6() []Ipv6Connectivity {
 		}
 	}
 	return r
+}
+
+func (d *DeviceInfo) findIPv4(id string) *Ipv4Connectivity {
+	for _, v := range d.getIPv4() {
+		if v.Id != nil && *v.Id == id {
+			c := v
+			return &c
+		}
+	}
+	return nil
+}
+
+func (d *DeviceInfo) findIPv6(id string) *Ipv6Connectivity {
+	for _, v := range d.getIPv6() {
+		if v.Id != nil && *v.Id == id {
+			c := v
+			return &c
+		}
+	}
+	return nil
 }

--- a/model/network_test.go
+++ b/model/network_test.go
@@ -61,7 +61,7 @@ func TestNetwork(t *testing.T) {
 		assert.NotEmpty(t, id)
 		assert.NoError(t, err)
 
-		id, err = m.AddIPv4("nic99", "172.16.0.1", "255.255.255.0", "")
+		id, err = m.AddIPv4("nic0", "172.16.0.1", "", "")
 		assert.Empty(t, id)
 		assert.Error(t, err)
 
@@ -243,16 +243,10 @@ func TestAddIPv6_Validation(t *testing.T) {
 		}
 	})
 
-	t.Run("Invalid router IPv6 address should return ValidationError", func(t *testing.T) {
+	t.Run("Invalid router IPv6 address should be ignored with warning", func(t *testing.T) {
 		id, err := m.AddIPv6(nicId, "2001:0db8:85a3:0000:0000:8a2e:0370:7334", "2001:db8:/64", "invalid-router")
-		assert.Empty(t, id)
-		assert.Error(t, err)
-		var ve *ValidationError
-		if errors.As(err, &ve) {
-			assert.Equal(t, "RouterIPv6Address", ve.Field)
-			assert.Equal(t, "Router IPv6 address format is invalid. Please refer to the base schema for the supported pattern.", ve.Message)
-			assert.Equal(t, "invalid-router", ve.Value)
-		}
+		assert.NotEmpty(t, id)
+		assert.NoError(t, err)
 	})
 }
 

--- a/model/network_test.go
+++ b/model/network_test.go
@@ -72,7 +72,12 @@ func TestNetwork(t *testing.T) {
 
 		id, err = m.AddIPv4("nic101", "", "", "")
 		assert.Empty(t, id)
-		assert.NoError(t, err)
+		assert.Error(t, err)
+		var ee *EmptyError
+		if errors.As(err, &ee) {
+			assert.Equal(t, "Ipv4Connectivity", ee.Field)
+			assert.Equal(t, "All fields for Ipv4Connectivity are empty", ee.Message)
+		}
 
 		id, err = m.AddIPv4("nic102", "999.999.999.999", "255.255.255.0", "10.0.0.254")
 		assert.NotEmpty(t, id)
@@ -114,6 +119,15 @@ func TestNetwork(t *testing.T) {
 		assert.Equal(t, "2001:0db8:85a3:0000:0000:8a2e:0370:7334", cp.Ipv6Address)
 		assert.Nil(t, cp.Ipv6NetworkPrefix)
 		assert.Nil(t, cp.RouterIpv6Address)
+
+		id3, err3 := m.AddIPv6("nic101", "", "", "")
+		assert.Empty(t, id3)
+		assert.Error(t, err3)
+		var ee *EmptyError
+		if errors.As(err3, &ee) {
+			assert.Equal(t, "Ipv6Connectivity", ee.Field)
+			assert.Equal(t, "All fields for Ipv6Connectivity are empty", ee.Message)
+		}
 
 		found := 0
 		for _, v := range m.getIPv6() {


### PR DESCRIPTION
### Description

Replaced early return on invalid Router IPv4 and IPv6 address with a warning log that skips setting the address, allowing execution to continue instead of aborting.


#### Change Type

Please select the relevant options:

- [x] Bug fix (non-breaking change that resolves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

#### Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document.
- [x] My changes adhere to the established code style, patterns, and best practices.
- [x] I have added tests that demonstrate the effectiveness of my changes.
- [x] I have updated the documentation accordingly (if applicable).
