### PR TITLE
fix(registryclient): support of app-type "iah-discover"

### DIFF
--- a/assetlink/al.go
+++ b/assetlink/al.go
@@ -126,6 +126,8 @@ func (d *AssetLink) Start(grpcServerAddress, registrationAddress, grpcRegistryAd
 	// if a custom discovery server is provided, register it
 	case d.customDiscoveryServer != nil:
 		log.Info().Msg("Registered existing discovery server")
+
+		registryclient.AddCsAppType(registryclient.APPTYPE_IAH_DISCOVER)
 		registryclient.AddCsInterface(registryclient.INTERFACE_IAH_DISCOVER_V1)
 
 		generatedDiscoveryServer.RegisterDeviceDiscoverApiServer(d.grpcServer, d.customDiscoveryServer)
@@ -134,6 +136,8 @@ func (d *AssetLink) Start(grpcServerAddress, registrationAddress, grpcRegistryAd
 	case d.discoveryImpl != nil:
 		log.Info().
 			Msg("Registered Discovery feature implementation")
+
+		registryclient.AddCsAppType(registryclient.APPTYPE_IAH_DISCOVER)
 		registryclient.AddCsInterface(registryclient.INTERFACE_IAH_DISCOVER_V1)
 
 		discoveryServer := &devicediscovery.DiscoverServerEntity{

--- a/cookiecutter-project-template/{{ cookiecutter.al_project }}/registry.json
+++ b/cookiecutter-project-template/{{ cookiecutter.al_project }}/registry.json
@@ -1,6 +1,7 @@
 {
 "app_instance_id": "cdm-device-class-driver-{{cookiecutter.al_id}}",
-"app_types": ["siemens.connectivitysuite.drvinfo.v1", "siemens.industrialassethub.discover.v1", "siemens.connectivitysuite.deviceinfo.v1"],
+"app_types": ["iah-discover"],
+"interfaces": ["siemens.connectivitysuite.drvinfo.v1", "siemens.industrialassethub.discover.v1", "siemens.connectivitysuite.deviceinfo.v1"],
 "driver_schema_uris": ["{{cookiecutter.al_id}}"]
 }
 

--- a/internal/registryclient/registryclient.go
+++ b/internal/registryclient/registryclient.go
@@ -25,11 +25,19 @@ type appTypes int
 const (
 	CDM_AGENT               appTypes = 0
 	CDM_DEVICE_CLASS_DRIVER appTypes = 1
+	IAH_DISCOVER            appTypes = 2
 )
 
 func (apptypes appTypes) String() string {
-	return []string{"cdm-agent", "cdm-device-class-driver"}[apptypes]
+	return []string{APPTYPE_CDM_AGENT, APPTYPE_CDM_DEVICE_CLASS_DRIVER, APPTYPE_IAH_DISCOVER}[apptypes]
 }
+
+// CS registry registered AppTypes which are served by the AL
+const (
+	APPTYPE_CDM_AGENT               = "cdm-agent"
+	APPTYPE_CDM_DEVICE_CLASS_DRIVER = "cdm-device-class-driver"
+	APPTYPE_IAH_DISCOVER            = "iah-discover"
+)
 
 // CS registry registered interfaces (former AppType) which are served by the AL
 const (
@@ -38,11 +46,20 @@ const (
 	INTERFACE_CONN_SUITE_DEVICEINFO_V1 = "siemens.connectivitysuite.deviceinfo.v1"
 )
 
-// Global list of available CS interfaces
+// Global list of available CS app types and interfaces
+var availableCSAppTypes []string
 var availableCSInterfaces []string
 
-func AddCsInterface(appType string) {
-	availableCSInterfaces = append(availableCSInterfaces, appType)
+func AddCsAppType(appType string) {
+	availableCSAppTypes = append(availableCSAppTypes, appType)
+}
+
+func AddCsInterface(csInterface string) {
+	availableCSInterfaces = append(availableCSInterfaces, csInterface)
+}
+
+func getCsAppTypes() []string {
+	return availableCSAppTypes
 }
 
 func getCsInterfaces() []string {
@@ -195,7 +212,7 @@ func (r *GrpcServerRegistry) register() (uint32, error) {
 		return retryRegistrationInterval, err
 	}
 	register := pb.RegisterServiceRequest{Info: &pb.ServiceInfo{
-		AppTypes:         getCsInterfaces(),
+		AppTypes:         getCsAppTypes(),
 		Interfaces:       getCsInterfaces(),
 		AppInstanceId:    r.appInstanceId,
 		DriverSchemaUris: []string{r.alId},

--- a/internal/registryclient/registryclient_test.go
+++ b/internal/registryclient/registryclient_test.go
@@ -252,7 +252,7 @@ func TestRegisterFunc(t *testing.T) {
 		r.appInstanceId = CDM_DEVICE_CLASS_DRIVER.String() + "-" + "test-al"
 
 		register := &pb.RegisterServiceRequest{Info: &pb.ServiceInfo{
-			AppTypes:         getCsInterfaces(),
+			AppTypes:         getCsAppTypes(),
 			Interfaces:       getCsInterfaces(),
 			AppInstanceId:    r.appInstanceId,
 			DriverSchemaUris: []string{r.alId},

--- a/misc/registry.json
+++ b/misc/registry.json
@@ -1,5 +1,6 @@
 {
 "app_instance_id": "cdm-device-class-driver-siemens.cdm.al.reference",
-"app_types": ["siemens.connectivitysuite.drvinfo.v1", "siemens.industrialassethub.discover.v1", "siemens.common.identifiers.v1"],
+"app_types": ["iah-discover"],
+"interfaces": ["siemens.connectivitysuite.drvinfo.v1", "siemens.industrialassethub.discover.v1"],
 "driver_schema_uris": ["siemens.cdm.al.reference"]
 }


### PR DESCRIPTION
### Description

Add support for app-type "Iah-discover"

#### Issues Addressed

#272 

#### Change Type

Please select the relevant options:

- [X] Bug fix (non-breaking change that resolves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

